### PR TITLE
Updated test logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-client",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "an api wrapper for Amazon Marketplace Webservice API",
   "main": "index.js",
   "scripts": {
-    "test": "nyc --reporter=lcov mocha",
+    "test": "node ./scripts/test.js",
     "lint": "standard --fix",
-    "coverage": "nyc --reporter=html mocha && xdg-open ./coverage/index.html",
+    "coverage": "node ./scripts/coverage.js",
     "add-section": "node tools/section-generator.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-client",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "description": "an api wrapper for Amazon Marketplace Webservice API",
   "main": "index.js",
   "scripts": {

--- a/scripts/coverage.js
+++ b/scripts/coverage.js
@@ -1,0 +1,6 @@
+const spawnSync = require('child_process').spawnSync
+
+require('./utils/set-env.js')
+
+spawnSync('nyc', ['--reporter=html', 'mocha'], { stdio: 'inherit' })
+spawnSync('xdg-open', ['./coverage/index.html'], { stdio: 'inherit' })

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,5 @@
+const spawnSync = require('child_process').spawnSync
+
+require('./utils/set-env.js')
+
+spawnSync('nyc', ['--reporter=lcov', 'mocha'], { stdio: 'inherit' })

--- a/scripts/utils/set-env.js
+++ b/scripts/utils/set-env.js
@@ -1,0 +1,17 @@
+if (!process.env.GITHUB_ACTIONS) {
+  const fs = require('fs')
+  const path = require('path')
+  const dotenv = require('dotenv')
+  const confPath = path.join(__dirname, '..', '..', 'test', '.env')
+  if (!fs.existsSync(confPath)) {
+    console.log('No environment configuration file found in test, stopping process...')
+    process.exit()
+  }
+  dotenv.config({ path: confPath })
+} else {
+  const missingEnvVars = ['AWS_ACCESS_KEY', 'MWS_AUTH_TOKEN', 'SELLER_ID'].filter(envVar => !process.env[envVar])
+  if (missingEnvVars.length > 0) {
+    console.log(`Missing environment ${missingEnvVars.length > 1 ? 'variables' : 'variable'} ${missingEnvVars.join(', ')}, stopping process...`)
+    process.exit()
+  }
+}

--- a/test/fulfillmentInventory.test.js
+++ b/test/fulfillmentInventory.test.js
@@ -1,5 +1,4 @@
 /* eslint no-undef: "off" */
-require('./utils/set-env.js')
 const MWS = require('../')({ AWSAccessKeyId: process.env.AWS_ACCESS_KEY, SellerId: process.env.SELLER_ID, MWSAuthToken: process.env.MWS_AUTH_TOKEN })
 
 var assert = require('assert')

--- a/test/mws.test.js
+++ b/test/mws.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-require('./utils/set-env.js')
 const version = require('../package.json').version
 
 var assert = require('assert')

--- a/test/utils/set-env.js
+++ b/test/utils/set-env.js
@@ -1,6 +1,0 @@
-// assuming that in the context of GitHub Actions the action is setup to properly bind environment variables to their corresponding secrets (we won't commit .env files!)
-if (!process.env.GITHUB_ACTIONS) {
-  const path = require('path')
-  const dotenv = require('dotenv')
-  dotenv.config({ path: path.join(__dirname, '..', '.env') })
-}


### PR DESCRIPTION
- simplified test logic so that global environment setup is done before running test suite (instead of running it for each test)
- bumped package version to `1.0.0`

Won't write full automated tests for now. Could do for `get` type of requests but not any `set` type of requests or requests which would act upon a Seller account. Will expand on automated testing later on when need will appear.