### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,33 @@ on:
     paths:
       - 'index.js'
       - 'api/**'
+      - 'data/**'
       - 'test/**'
       - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   coverage:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,33 @@ on:
     paths:
       - 'index.js'
       - 'api/**'
-      - 'package.json'
-      - 'docs/**'
       - 'data/**'
-      - 'README.md'
+      - 'docs/**'
+      - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   generate-docs:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Import GPG key

--- a/docs/template.md
+++ b/docs/template.md
@@ -4,18 +4,14 @@
 
 **GitHub Actions workflows status**
 
-[![](https://img.shields.io/github/workflow/status/kaskadi/mws-client/publish?label=publish&logo=npm)](https://github.com/kaskadi/mws-client/actions?query=workflow%3Apublish)
-[![](https://img.shields.io/github/workflow/status/kaskadi/mws-client/build?label=build&logo=mocha)](https://github.com/kaskadi/mws-client/actions?query=workflow%3Abuild)
+[![Build workflow status](https://img.shields.io/github/workflow/status/kaskadi/mws-client/build?label=build&logo=mocha)](https://github.com/kaskadi/mws-client/actions?query=workflow%3Abuild)
+[![Publish workflow status](https://img.shields.io/github/workflow/status/kaskadi/mws-client/publish?label=publish&logo=npm)](https://github.com/kaskadi/mws-client/actions?query=workflow%3Apublish)
 
 **CodeClimate**
 
 [![](https://img.shields.io/codeclimate/maintainability/kaskadi/mws-client?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/mws-client)
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/mws-client?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/mws-client)
 [![](https://img.shields.io/codeclimate/coverage/kaskadi/mws-client?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/mws-client)
-
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/mws-client?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/mws-client/?mode=list&logo=LGTM)
 
 ****
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mws-client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "an api wrapper for Amazon Marketplace Webservice API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` and `publish` workflow.

**Updated features**
- _`build`/`publish` workflow:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository
- _documentation template:_ updated badges to remove `LGTM` badges and add alternative text.